### PR TITLE
[bugfix] issue 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
             cargo install cargo-deb
             RUSTFLAGS="-Cllvm-args=-pgo-warn-missing-function -Cprofile-use=$(pwd)/pgo-data/merged.profdata" cargo deb
             deb_path=$(find ./target/debian/ -type f -name 'hck*')
-            asset_path="./${{ matrix.asset_name }}.deb"
+            asset_path="${{ matrix.asset_name }}.deb"
             mv "${deb_path}" "${asset_path}"
             echo "DEB=${asset_path}" >> $GITHUB_ENV
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [PR24](https://github.com/sstadick/hck/pull/24) Removed the now defunct profile guided optimization shell scripts and all references to them in favor of the `justfile` that was added in `v0.5.0`
 - [Bugfix](https://github.com/sstadick/hck/issues/26) fixes incorrect handling of header line for non-stdin inputs, fixes incorrect parsing of last header fields (now strips newline before matching), fixes option parsing so that the `-F` and `-E` options wont' try to consume the positional input arguments. Huge thanks to @learnbyexample for their detailed bug report.
+- Change: An error will now be raised when a specified header is not found. This differs from the convention used by the selecion-by-index, which tries to match `cut`. The reasoning is that it is generally harder to type out each header field and if a header is not found you want to know about it.
 
 ## v0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v0.5.2-alpha (in progress)
+## v0.5.2
 
 - [PR24](https://github.com/sstadick/hck/pull/24) Removed the now defunct profile guided optimization shell scripts and all references to them in favor of the `justfile` that was added in `v0.5.0`
+- [Bugfix](https://github.com/sstadick/hck/issues/26) fixes incorrect handling of header line for non-stdin inputs, fixes incorrect parsing of last header fields (now strips newline before matching), fixes option parsing so that the `-F` and `-E` options wont' try to consume the positional input arguments. Huge thanks to @learnbyexample for their detailed bug report.
 
 ## v0.5.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,9 +573,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static",
@@ -584,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -228,6 +228,7 @@ impl<'a> CoreConfigBuilder<'a> {
     }
 
     /// Whether or not the parser is a regex
+    #[allow(clippy::wrong_self_convention)]
     pub fn is_regex_parser(mut self, is_regex: bool) -> Self {
         self.config.is_parser_regex = is_regex;
         self


### PR DESCRIPTION
Fixes:
- incorrect handling of parsed-header line when not reading from stdin
- strips newline before trying to match headers
- fixes option parsing to not consume positional args when parsing `-F` and `-E`
- Now raises error when header fields are missing