### PR TITLE
[bugfix] Handle fast-track inputs with multiple blank lines at the start

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,3 +80,9 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Install cargo-bundle-licenses
+        run: cargo install cargo-bundle-licenses
+      
+      - name: Check licenses
+        run: cargo bundle-licenses --format yaml --output CI.THIRDPARTY.yml --previous THIRDPARTY.yml --check-previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.6.5
+
+- [Bugfix](https://github.com/sstadick/hck/issues/38) for files using fast-path code that have empty first lines
+
+## v0.6.4
+
+- Added thirdparty license in prep for conda-forge
+
 ## v0.6.3
 
 - Change the number of compression threads used by default

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -462,7 +462,23 @@ where
         let sep = self.config.delimiter[0];
         let newline = self.config.line_terminator.as_byte();
 
-        let iter = memchr::memchr2_iter(sep, newline, bytes);
+        let mut iter = memchr::memchr2_iter(sep, newline, bytes).peekable();
+        // Peek at first matches to check if they are empty lines, consume them if they are.
+        // We need to skip ahead to the point where we have values pushed onto lines before
+        // hitting a newline.
+        while let Some(&index) = iter.peek() {
+            if index == 0 && bytes[index] == newline {
+                output.join_append(
+                    self.config.output_delimiter,
+                    std::iter::empty(),
+                    &self.config.line_terminator,
+                )?;
+                // Consume the iterator position
+                let _ = iter.next();
+            } else {
+                break;
+            }
+        }
 
         let mut line = vec![];
         let mut start = 0;
@@ -512,7 +528,25 @@ where
         let mut line = vec![];
         while reader.fill().unwrap() {
             let bytes = reader.buffer();
-            let iter = memchr::memchr2_iter(sep, newline, bytes);
+            let mut iter = memchr::memchr2_iter(sep, newline, bytes).peekable();
+
+            // Peek at first matches to check if they are empty lines, consume them if they are.
+            // We need to skip ahead to the point where we have values pushed onto lines before
+            // hitting a newline.
+            while let Some(&index) = iter.peek() {
+                if index == 0 && bytes[index] == newline {
+                    output.join_append(
+                        self.config.output_delimiter,
+                        std::iter::empty(),
+                        &self.config.line_terminator,
+                    )?;
+                    // Consume the iterator position
+                    let _ = iter.next();
+                } else {
+                    break;
+                }
+            }
+
             let mut start = 0;
 
             for index in iter {

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -466,7 +466,7 @@ where
         // Peek at first matches to check if they are empty lines, consume them if they are.
         // We need to skip ahead to the point where we have values pushed onto lines before
         // hitting a newline.
-        while let Some(&index) = iter.peek() {
+        if let Some(&index) = iter.peek() {
             if index == 0 && bytes[index] == newline {
                 output.join_append(
                     self.config.output_delimiter,
@@ -475,8 +475,6 @@ where
                 )?;
                 // Consume the iterator position
                 let _ = iter.next();
-            } else {
-                break;
             }
         }
 
@@ -533,7 +531,7 @@ where
             // Peek at first matches to check if they are empty lines, consume them if they are.
             // We need to skip ahead to the point where we have values pushed onto lines before
             // hitting a newline.
-            while let Some(&index) = iter.peek() {
+            if let Some(&index) = iter.peek() {
                 if index == 0 && bytes[index] == newline {
                     output.join_append(
                         self.config.output_delimiter,
@@ -542,8 +540,6 @@ where
                     )?;
                     // Consume the iterator position
                     let _ = iter.next();
-                } else {
-                    break;
                 }
             }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 pub mod core;
 pub mod field_range;
 pub mod line_parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1420,6 +1420,8 @@ mod test {
             vec![""],
             vec![""],
             vec!["a", "b", "c", "d", "e", "f", "g"],
+            vec![""],
+            vec![""],
             vec!["1", "2", "3", "4", "5", "6", "7"],
         ];
         write_file(&input_file, data, hck_delim);
@@ -1433,6 +1435,8 @@ mod test {
                 vec![""],
                 vec![""],
                 vec!["b", "c", "d", "e", "f", "g"],
+                vec![""],
+                vec![""],
                 vec!["2", "3", "4", "5", "6", "7"]
             ]
         );


### PR DESCRIPTION
No performance regression in benchmarks. 