### PR TITLE
[bugfix] Fix fast-path splitting when there are empty lines at the start of the file

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,3 +80,9 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+      - name: Install cargo-bundle-licenses
+        run: cargo install cargo-bundle-licenses
+      
+      - name: Check licenses
+        run: cargo bundle-licenses --format yaml --output CI.THIRDPARTY.yml --previous THIRDPARTY.yml --check-previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.6.5
+
+- [Bugfix](https://github.com/sstadick/hck/issues/38) for files using fast-path code that have empty first lines
+
+## v0.6.4
+
+- Added thirdparty license in prep for conda-forge
+
 ## v0.6.3
 
 - Change the number of compression threads used by default

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -462,7 +462,23 @@ where
         let sep = self.config.delimiter[0];
         let newline = self.config.line_terminator.as_byte();
 
-        let iter = memchr::memchr2_iter(sep, newline, bytes);
+        let mut iter = memchr::memchr2_iter(sep, newline, bytes).peekable();
+        // Peek at first matches to check if they are empty lines, consume them if they are.
+        // We need to skip ahead to the point where we have values pushed onto lines before
+        // hitting a newline.
+        while let Some(&index) = iter.peek() {
+            if index == 0 && bytes[index] == newline {
+                output.join_append(
+                    self.config.output_delimiter,
+                    std::iter::empty(),
+                    &self.config.line_terminator,
+                )?;
+                // Consume the iterator position
+                let _ = iter.next();
+            } else {
+                break;
+            }
+        }
 
         let mut line = vec![];
         let mut start = 0;
@@ -512,7 +528,25 @@ where
         let mut line = vec![];
         while reader.fill().unwrap() {
             let bytes = reader.buffer();
-            let iter = memchr::memchr2_iter(sep, newline, bytes);
+            let mut iter = memchr::memchr2_iter(sep, newline, bytes).peekable();
+
+            // Peek at first matches to check if they are empty lines, consume them if they are.
+            // We need to skip ahead to the point where we have values pushed onto lines before
+            // hitting a newline.
+            while let Some(&index) = iter.peek() {
+                if index == 0 && bytes[index] == newline {
+                    output.join_append(
+                        self.config.output_delimiter,
+                        std::iter::empty(),
+                        &self.config.line_terminator,
+                    )?;
+                    // Consume the iterator position
+                    let _ = iter.next();
+                } else {
+                    break;
+                }
+            }
+
             let mut start = 0;
 
             for index in iter {

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -463,6 +463,7 @@ where
         let newline = self.config.line_terminator.as_byte();
 
         let mut iter = memchr::memchr2_iter(sep, newline, bytes).peekable();
+        let mut start = 0;
         // Peek at first matches to check if they are empty lines, consume them if they are.
         // We need to skip ahead to the point where we have values pushed onto lines before
         // hitting a newline.
@@ -474,12 +475,12 @@ where
                     &self.config.line_terminator,
                 )?;
                 // Consume the iterator position
+                start = index + 1;
                 let _ = iter.next();
             }
         }
 
         let mut line = vec![];
-        let mut start = 0;
         for index in iter {
             if bytes[index] == sep {
                 line.push((start, index - 1));
@@ -531,6 +532,7 @@ where
             // Peek at first matches to check if they are empty lines, consume them if they are.
             // We need to skip ahead to the point where we have values pushed onto lines before
             // hitting a newline.
+            let mut start = 0;
             if let Some(&index) = iter.peek() {
                 if index == 0 && bytes[index] == newline {
                     output.join_append(
@@ -538,12 +540,11 @@ where
                         std::iter::empty(),
                         &self.config.line_terminator,
                     )?;
+                    start = index + 1;
                     // Consume the iterator position
                     let _ = iter.next();
                 }
             }
-
-            let mut start = 0;
 
             for index in iter {
                 if bytes[index] == sep {

--- a/src/lib/core.rs
+++ b/src/lib/core.rs
@@ -466,7 +466,7 @@ where
         // Peek at first matches to check if they are empty lines, consume them if they are.
         // We need to skip ahead to the point where we have values pushed onto lines before
         // hitting a newline.
-        while let Some(&index) = iter.peek() {
+        if let Some(&index) = iter.peek() {
             if index == 0 && bytes[index] == newline {
                 output.join_append(
                     self.config.output_delimiter,
@@ -475,8 +475,6 @@ where
                 )?;
                 // Consume the iterator position
                 let _ = iter.next();
-            } else {
-                break;
             }
         }
 
@@ -533,7 +531,7 @@ where
             // Peek at first matches to check if they are empty lines, consume them if they are.
             // We need to skip ahead to the point where we have values pushed onto lines before
             // hitting a newline.
-            while let Some(&index) = iter.peek() {
+            if let Some(&index) = iter.peek() {
                 if index == 0 && bytes[index] == newline {
                     output.join_append(
                         self.config.output_delimiter,
@@ -542,8 +540,6 @@ where
                     )?;
                     // Consume the iterator position
                     let _ = iter.next();
-                } else {
-                    break;
                 }
             }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 pub mod core;
 pub mod field_range;
 pub mod line_parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1420,6 +1420,8 @@ mod test {
             vec![""],
             vec![""],
             vec!["a", "b", "c", "d", "e", "f", "g"],
+            vec![""],
+            vec![""],
             vec!["1", "2", "3", "4", "5", "6", "7"],
         ];
         write_file(&input_file, data, hck_delim);
@@ -1433,6 +1435,8 @@ mod test {
                 vec![""],
                 vec![""],
                 vec!["b", "c", "d", "e", "f", "g"],
+                vec![""],
+                vec![""],
                 vec!["2", "3", "4", "5", "6", "7"]
             ]
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1415,7 +1415,7 @@ mod test {
         let input_file = tmp.path().join("input.txt");
         let output_file = tmp.path().join("output.txt");
         // 4-5 should not be repeated at the end and only written once.
-        let opts = build_opts_not_regex(&input_file, &output_file, "2,3,4-", no_mmap, hck_delim);
+        let opts = build_opts_not_regex(&input_file, &output_file, "1,2", no_mmap, hck_delim);
         let data = vec![
             vec![""],
             vec![""],
@@ -1434,10 +1434,10 @@ mod test {
             vec![
                 vec![""],
                 vec![""],
-                vec!["b", "c", "d", "e", "f", "g"],
+                vec!["a", "b"],
                 vec![""],
                 vec![""],
-                vec!["2", "3", "4", "5", "6", "7"]
+                vec!["1", "2"]
             ]
         );
     }


### PR DESCRIPTION
No perf regression in benchmarks.
See tests.
Also adds `cargo-bundle-licenses` to CI