### PR TITLE
[bugfix] Fix unescaping of delim when using headers to specify columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.1
+
+- bugfix Apply unescaping to headers when selecting via `-F`
+
 ## v0.7.0
 
 - [Improvement](https://github.com/sstadick/hck/issues/46#issuecomment-974189408) Allow for passing escaped sequences in for the input and output delimiteres. i.e '\t' or '\n' can be passed in directly instead of needing to add $'\n' on the command line.

--- a/src/lib/field_range.rs
+++ b/src/lib/field_range.rs
@@ -28,16 +28,16 @@ pub enum FieldError {
 }
 
 #[derive(Debug, Clone)]
-pub enum RegexOrStr<'b> {
+pub enum RegexOrString {
     Regex(Regex),
-    Str(&'b str),
+    String(String),
 }
 
-impl<'b> RegexOrStr<'b> {
-    fn split(&'b self, line: &'b [u8]) -> Box<dyn Iterator<Item = &'b [u8]> + 'b> {
+impl RegexOrString {
+    fn split<'a>(&'a self, line: &'a [u8]) -> Box<dyn Iterator<Item = &'a [u8]> + 'a> {
         match self {
-            RegexOrStr::Regex(r) => Box::new(r.split(line)),
-            RegexOrStr::Str(s) => Box::new(line.split_str(s)),
+            RegexOrString::Regex(r) => Box::new(r.split(line)),
+            RegexOrString::String(s) => Box::new(line.split_str(s)),
         }
     }
 }
@@ -151,7 +151,7 @@ impl FieldRange {
     pub fn from_header_list(
         list: &[Regex],
         header: &[u8],
-        delim: &RegexOrStr,
+        delim: &RegexOrString,
         header_is_regex: bool,
         allow_missing: bool,
     ) -> Result<Vec<FieldRange>, FieldError> {
@@ -349,7 +349,7 @@ mod test {
     fn test_parse_header_fields() {
         let header = b"is_cat-isdog-wascow-was_is_apple-12345-!$%*(_)";
         let delim = Regex::new("-").unwrap();
-        let delim = RegexOrStr::Regex(delim);
+        let delim = RegexOrString::Regex(delim);
         let header_fields = vec![
             Regex::new(r"^is_.*$").unwrap(),
             Regex::new("dog").unwrap(),
@@ -378,7 +378,7 @@ mod test {
     fn test_parse_header_fields_literal() {
         let header = b"is_cat-is-isdog-wascow-was_is_apple-12345-!$%*(_)";
         let delim = Regex::new("-").unwrap();
-        let delim = RegexOrStr::Regex(delim);
+        let delim = RegexOrString::Regex(delim);
         let header_fields = vec![Regex::new(r"is").unwrap()];
         let fields =
             FieldRange::from_header_list(&header_fields, header, &delim, false, false).unwrap();
@@ -396,7 +396,7 @@ mod test {
     fn test_parse_header_fields_literal_header_not_found() {
         let header = b"is_cat-is-isdog-wascow-was_is_apple-12345-!$%*(_)";
         let delim = Regex::new("-").unwrap();
-        let delim = RegexOrStr::Regex(delim);
+        let delim = RegexOrString::Regex(delim);
         let header_fields = vec![
             Regex::new(r"^is_.*$").unwrap(),
             Regex::new("dog").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use grep_cli::{stdout, unescape};
 use gzp::{deflate::Bgzf, ZBuilder};
 use hcklib::{
     core::{Core, CoreConfig, CoreConfigBuilder, HckInput},
-    field_range::RegexOrStr,
+    field_range::RegexOrString,
     line_parser::{RegexLineParser, SubStrLineParser},
     mmap::MmapChoice,
 };
@@ -315,7 +315,7 @@ fn run<W: Write>(
     }
 
     match conf.parsed_delim() {
-        RegexOrStr::Regex(regex) => {
+        RegexOrString::Regex(regex) => {
             let mut core = Core::new(
                 conf,
                 &fields,
@@ -324,7 +324,7 @@ fn run<W: Write>(
             );
             core.hck_input(input, writer, extra)?;
         }
-        RegexOrStr::Str(s) => {
+        RegexOrString::String(s) => {
             let s = unescape(s);
             let mut core = Core::new(
                 conf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,11 +325,11 @@ fn run<W: Write>(
             core.hck_input(input, writer, extra)?;
         }
         RegexOrString::String(s) => {
-            let s = unescape(s);
+            // let s = unescape(s);
             let mut core = Core::new(
                 conf,
                 &fields,
-                SubStrLineParser::new(&fields, &s),
+                SubStrLineParser::new(&fields, s.as_bytes()),
                 line_buffer,
             );
             core.hck_input(input, writer, extra)?;


### PR DESCRIPTION
`hck -Ld'\t' -F header_name <file>` was not unescaping the delimiter when parsing the header line. This fix moves unescaping the delim to the earliest possible time (when creating the `RegexOrString` delim in the `CoreConfBuilder`) so all cases should now be handled as it is the `CoreConf::parsed_delim` that is used throughout. 