### PR TITLE
Add how to install HCK in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ curl -LO https://github.com/sstadick/hck/releases/download/<latest>/hck-linux-am
 sudo dpkg -i hck-linux-amd64.deb
 ```
 
+- Windows (with [scoop](https://scoop.sh/))
+
+```bash
+scoop bucket add scoop-aoks https://github.com/AntonOks/scoop-aoks.git
+scoop install hck-aoks
+```
+
 \* Built with profile guided optimizations
 
 - With the Rust toolchain:


### PR DESCRIPTION
For now one will have to add my SCOOP repo to install HCK via SCOOP.
Once #52 is fixed, I will send a pull request to https://github.com/ScoopInstaller/Extras to make HCK available with the default SCOOP installation