### PR TITLE
Update Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ Think of this as filling a gap between `cut` and `awk`.
 
 ## Install
 
-- Homebrew / Linuxbrew
+- Homebrew
 
 ```bash
-brew tap sstadick/hck
 brew install hck
 ```
 


### PR DESCRIPTION
hck is available through homebrew/core: https://formulae.brew.sh/formula/hck

From https://docs.brew.sh/Homebrew-on-Linux:

> Homebrew was formerly referred to as Linuxbrew when running on Linux or WSL.